### PR TITLE
Added an option to move party buffs for EasyFrames

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -152,6 +152,21 @@ function smb:CreateOptions()
 		end,
 		'currentTextFunc', function(value) return ("%.0f"):format(value) end)
 	numLines:SetPoint("TOPLEFT",perLine,"BOTTOMLEFT",0,-30)
+	
+	local lowerOffset = panel:MakeToggle(
+    'name', 'Lower buff offset for EasyFrames',
+    'description', 'Move buffs slightly lower (good for EasyFrames party frames)',
+    'default', false,
+    'getFunc', function() 
+        return ShowMeBuffDB and ShowMeBuffDB.buffs and ShowMeBuffDB.buffs.lowerBuffOffset or false 
+    end,
+    'setFunc', function(value)
+        if ShowMeBuffDB and ShowMeBuffDB.buffs then
+            ShowMeBuffDB.buffs.lowerBuffOffset = value
+            smb.LoadBuffs()
+        end
+    end)
+	lowerOffset:SetPoint("TOPLEFT", player, "BOTTOMLEFT", 0, -5)
 end
 
 -- Slash commands

--- a/Options.lua
+++ b/Options.lua
@@ -89,14 +89,14 @@ function smb:CreateOptions()
 		'name', 'Hide longer than',
 		'description', 'Time in minutes',
 		'minText', '0',
-		'maxText', '60',
+		'maxText', '180',
 		'minValue', 0,
-		'maxValue', 60,
+		'maxValue', 180,
 		'step', 5,
 		'default', 10,
-		'current', ShowMeBuffDB.buffs.hideDuration/60,
+		'current', ShowMeBuffDB.buffs.hideDuration/180,
 		'setFunc', function(value)
-			ShowMeBuffDB.buffs.hideDuration = value*60
+			ShowMeBuffDB.buffs.hideDuration = value*180
 			smb.LoadBuffs()
 		end,
 		'currentTextFunc', function(value) return ("%.0f"):format(value) end)

--- a/Options.lua
+++ b/Options.lua
@@ -167,6 +167,21 @@ function smb:CreateOptions()
         end
     end)
 	lowerOffset:SetPoint("TOPLEFT", player, "BOTTOMLEFT", 0, -5)
+	
+	local buffsOnTop = panel:MakeToggle(
+    'name', 'Player buffs on top',
+    'description', 'Show player buffs above the player frame instead of below',
+    'default', false,
+    'getFunc', function() 
+        return ShowMeBuffDB and ShowMeBuffDB.buffs and ShowMeBuffDB.buffs.buffsOnTop or false 
+    end,
+    'setFunc', function(value)
+        if ShowMeBuffDB and ShowMeBuffDB.buffs then
+            ShowMeBuffDB.buffs.buffsOnTop = value
+            smb.LoadBuffs()
+        end
+    end)
+	buffsOnTop:SetPoint("TOPLEFT", lowerOffset, "BOTTOMLEFT", 0, -5)
 end
 
 -- Slash commands

--- a/ShowMeBuff.lua
+++ b/ShowMeBuff.lua
@@ -82,6 +82,7 @@ smbDefaults = {
 		numLines = 18,
 		numPerLine = 6,
 		buffSize = 15,
+		lowerBuffOffset = false,
 	},
 	debuffs = {
 		hideNames = {
@@ -223,7 +224,8 @@ function LoadUnitBuffs(rules, pointX, pointY, f)
 		c:SetSize(rules.buffSize, rules.buffSize)
 		c:ClearAllPoints()
 		if j == 1 then
-			c:SetPoint("TOPLEFT",pointX,pointY)
+			local offsetY = ShowMeBuffDB.buffs.lowerBuffOffset and -10 or 0
+			c:SetPoint("TOPLEFT", pointX, pointY + offsetY)
 		elseif ((j - 1) % rules.numPerLine) == 0 then
 			c:SetPoint("TOPLEFT",_G[l..(j - rules.numPerLine)],"BOTTOMLEFT", 0, -1)
 		else

--- a/ShowMeBuff.lua
+++ b/ShowMeBuff.lua
@@ -83,6 +83,7 @@ smbDefaults = {
 		numPerLine = 6,
 		buffSize = 15,
 		lowerBuffOffset = false,
+		buffsOnTop = false,
 	},
 	debuffs = {
 		hideNames = {
@@ -102,7 +103,7 @@ smbDefaults = {
 		buffSize = 15,
 	},
 	debug = false,
-	verson = 1,
+	version = 1,
 }
 
 local mountIds = {
@@ -320,7 +321,21 @@ local function LoadBuffs()
 	end
 
 	LoadPartyBuffs(ShowMeBuffDB.buffs, 48, BUFF_POINT)
-	-- LoadUnitBuffs(ShowMeBuffDB.buffs, -100, 0, PlayerFrame)
+	-- Player buffs: top or bottom
+	if ShowMeBuffDB.buffs.buffsOnTop then
+		if ShowMeBuffDB.buffs.lowerBuffOffset then
+			LoadUnitBuffs(ShowMeBuffDB.buffs, 110, 20, PlayerFrame)
+		else
+			LoadUnitBuffs(ShowMeBuffDB.buffs, 110, 10, PlayerFrame)
+		end
+	else
+		if ShowMeBuffDB.buffs.lowerBuffOffset then
+			LoadUnitBuffs(ShowMeBuffDB.buffs, 110, -60, PlayerFrame)
+		else
+			LoadUnitBuffs(ShowMeBuffDB.buffs, 110, -70, PlayerFrame)
+		end
+	end
+
 end
 
 local function LoadDebuffs()
@@ -332,7 +347,11 @@ local function LoadDebuffs()
 	end
 	
 	LoadPartyDebuffs(ShowMeBuffDB.debuffs, 48, DEBUFF_POINT)
-	-- LoadUnitDebuffs(ShowMeBuffDB.debuffs, -100, -50, PlayerFrame)
+	if ShowMeBuffDB.buffs.buffsOnTop then
+		LoadUnitDebuffs(ShowMeBuffDB.debuffs, 110, 35, PlayerFrame)
+	else
+		LoadUnitDebuffs(ShowMeBuffDB.debuffs, 110, -95, PlayerFrame)
+	end
 end
 
 local function SmbLoaded(self)


### PR DESCRIPTION
Move buffs slightly lower to match with EasyFrames' Party Frames textures

Disabled
<img width="1249" height="687" alt="image" src="https://github.com/user-attachments/assets/c2cdca0d-b9b8-4ac5-a587-de96d80aae33" />

Enabled
<img width="1251" height="653" alt="image" src="https://github.com/user-attachments/assets/a77daf45-e131-4e1d-83b8-91b39f325f46" />
